### PR TITLE
cache images and refetch after 10mins

### DIFF
--- a/src/DetailPage.js
+++ b/src/DetailPage.js
@@ -115,7 +115,7 @@ function DetailPage({ box, setBox }) {
             type="file"
             accept="image/*"
             capture="environment"
-            class="form-control"
+            className="form-control"
             onChange={async (event) => {
               const file = event.target.files[0];
               const key = uuid();

--- a/src/Image.js
+++ b/src/Image.js
@@ -1,26 +1,35 @@
 import { Storage } from "@aws-amplify/storage";
 import { useState, useEffect } from "react";
+import { IMAGE_URL_EXPIRATION } from "./constants";
+import { addToCache, getFromCache } from "./helpers/cache";
 
 function Image({ imgKey, actions }) {
   const [dig, setDig] = useState(false);
   const [src, setSrc] = useState(null);
   useEffect(() => {
     (async () => {
-      const url = await Storage.get(imgKey, { level: "private" });
-      setSrc(url);
+      const cachedUrl = getFromCache(imgKey);
+      if (cachedUrl) {
+        setSrc(cachedUrl);
+      } else {
+        const url = await Storage.get(imgKey, { level: "private", expires: IMAGE_URL_EXPIRATION });
+        setSrc(url);
+        addToCache(imgKey, url);
+      }
     })();
-  }, []);
+  });
   return (
-    <div class="p-0">
+    <div className="p-0">
       <img
         className="img-fluid border"
         src={src}
         onClick={() => {
           setDig(!dig);
         }}
+        alt={imgKey}
       />
       {dig && actions && (
-        <div class="d-flex justify-content-between">
+        <div className="d-flex justify-content-between">
           {actions.map((action) => (
             <button
               key={action.text}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,1 @@
+export const IMAGE_URL_EXPIRATION = 600;  // seconds

--- a/src/helpers/cache.js
+++ b/src/helpers/cache.js
@@ -1,0 +1,23 @@
+import { IMAGE_URL_EXPIRATION } from "../constants";
+
+export function addToCache(key, value) {
+  const createdAt = (new Date()).getTime();
+  localStorage.setItem(key, JSON.stringify({ value, createdAt }));
+}
+
+export function getFromCache(key) {
+  const item = localStorage.getItem(key);
+  if (item) {
+    const itemObject = JSON.parse(item);
+    if (!isExpired(itemObject.createdAt)) {
+      return itemObject.value;
+    } else {
+      localStorage.removeItem(key);
+    }
+  }
+}
+
+function isExpired(createdAt) {
+  const now = (new Date()).getTime();
+  return (now - createdAt) >= (IMAGE_URL_EXPIRATION * 1000 * .9);
+}


### PR DESCRIPTION
- set URLs returned from Amplify `Storage.get` to expire after 600s
- storage each URL from `Storage.get` to local storage
- refetch a new URL if the cache expires